### PR TITLE
fix: enable 10 digit zip codes

### DIFF
--- a/api-specification.yaml
+++ b/api-specification.yaml
@@ -373,7 +373,7 @@ components:
           description: city of the address
           example: Lauterach
         zipCode:
-          maxLength: 9
+          maxLength: 10
           type: string
           description: zipcode of the address
           example: '6923'

--- a/lib/Api/DefaultApi.php
+++ b/lib/Api/DefaultApi.php
@@ -29,8 +29,8 @@ namespace Towa\GebruederWeissSDK\Api;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;

--- a/lib/Model/Address.php
+++ b/lib/Model/Address.php
@@ -299,8 +299,8 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
             $invalidProperties[] = "invalid value for 'city', the character length must be smaller than or equal to 35.";
         }
 
-        if (!is_null($this->container['zip_code']) && (mb_strlen($this->container['zip_code']) > 9)) {
-            $invalidProperties[] = "invalid value for 'zip_code', the character length must be smaller than or equal to 9.";
+        if (!is_null($this->container['zip_code']) && (mb_strlen($this->container['zip_code']) > 10)) {
+            $invalidProperties[] = "invalid value for 'zip_code', the character length must be smaller than or equal to 10.";
         }
 
         return $invalidProperties;
@@ -589,8 +589,8 @@ class Address implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setZipCode($zip_code)
     {
-        if (!is_null($zip_code) && (mb_strlen($zip_code) > 9)) {
-            throw new \InvalidArgumentException('invalid length for $zip_code when calling Address., must be smaller than or equal to 9.');
+        if (!is_null($zip_code) && (mb_strlen($zip_code) > 10)) {
+            throw new \InvalidArgumentException('invalid length for $zip_code when calling Address., must be smaller than or equal to 10.');
         }
 
         $this->container['zip_code'] = $zip_code;


### PR DESCRIPTION
# TL;DR

Enable 10 digit zip codes because in the us zip codes are in format XXXX-XXXXX